### PR TITLE
Fix create of LDPC_matrix from alist file

### DIFF
--- a/gr-fec/python/fec/LDPC/Generate_LDPC_matrix_functions.py
+++ b/gr-fec/python/fec/LDPC/Generate_LDPC_matrix_functions.py
@@ -128,7 +128,7 @@ class LDPC_matrix(object):
                n_p_q = None,
                H_matrix = None):
     if (alist_filename != None):
-      self.H = self.read_alist_file(alist_filename)
+      self.H = read_alist_file(alist_filename)
     elif (n_p_q != None):
       self.H = self.regular_LDPC_code_contructor(n_p_q)
     elif (H_matrix != None):


### PR DESCRIPTION
read_alist_file is a function, not a method.